### PR TITLE
Fix method is not subscriptable

### DIFF
--- a/jam/dataset.py
+++ b/jam/dataset.py
@@ -448,7 +448,7 @@ class DBField(object):
 
     def check_reqired(self):
         if self.required and self.data is None:
-            raise FieldValueRequired('%s "%s" - %s' % (consts.language['field'], self.field_name, consts.language['value_required']))
+            raise FieldValueRequired('%s "%s" - %s' % (consts.language('field'), self.field_name, consts.language('value_required')))
         return True
 
     def check_valid(self):


### PR DESCRIPTION
```python
Traceback (most recent call last):
  File "C:\Sistemas WEB\Python\CairesCash2.0\env\lib\site-packages\jam\wsgi.py", line 628, in on_api
    data = self.get_response(item, method, params)
  File "C:\Sistemas WEB\Python\CairesCash2.0\env\lib\site-packages\jam\wsgi.py", line 655, in get_response        
    return self.server_func(item, params[0], params[1])
  File "C:\Sistemas WEB\Python\CairesCash2.0\env\lib\site-packages\jam\wsgi.py", line 666, in server_func
    result = func(obj, *params)
  File "cairescash.catalogs.item", line 78, in import_csv
    copy.post()
  File "C:\Sistemas WEB\Python\CairesCash2.0\env\lib\site-packages\jam\dataset.py", line 1579, in post
    self.check_record_valid()
  File "C:\Sistemas WEB\Python\CairesCash2.0\env\lib\site-packages\jam\dataset.py", line 1618, in check_record_valid
    field.check_valid()
  File "C:\Sistemas WEB\Python\CairesCash2.0\env\lib\site-packages\jam\dataset.py", line 455, in check_valid
    if self.check_reqired():
  File "C:\Sistemas WEB\Python\CairesCash2.0\env\lib\site-packages\jam\dataset.py", line 451, in check_reqired    
    raise FieldValueRequired('%s "%s" - %s' % (consts.language['field'], self.field_name, consts.language['value_required']))
TypeError: 'method' object is not subscriptable
```