### PR TITLE
Fix non scaped . dot on str_to_cur

### DIFF
--- a/jam/js/jam.js
+++ b/jam/js/jam.js
@@ -2882,7 +2882,7 @@
                 result = $.trim(val);
                 result = result.replace(' ', '')
                 if (locale.MON_THOUSANDS_SEP.length) {
-                    result = result.replace(new RegExp(locale.MON_THOUSANDS_SEP, 'g'), '');
+                    result = result.replace(new RegExp('\\' + locale.MON_THOUSANDS_SEP, 'g'), '');
                 }
                 if (locale.CURRENCY_SYMBOL) {
                     result = $.trim(result.replace(locale.CURRENCY_SYMBOL, ''));


### PR DESCRIPTION
The fact that there's a non scaped . (dot) on the RegExp constructor, make the replace fail, and return an empty string

```js
'R$1200,00'.replace(new RegExp('.', 'g'), '') -> ""
'R$1200,00'.replace(new RegExp('\\.', 'g'), '') -> "R$1200,00"
```